### PR TITLE
Do not set SHM_DEST on systems that do not support this non-standard mode.

### DIFF
--- a/rct/SharedMemory.cpp
+++ b/rct/SharedMemory.cpp
@@ -40,7 +40,7 @@ bool SharedMemory::init(key_t key, int size, CreateMode mode)
         memset(&ds, 0, sizeof(ds));
         ds.shm_perm.uid = getuid();
         ds.shm_perm.mode = 0600;
-#ifndef OS_Darwin
+#if !defined(OS_Darwin) && !defined(OS_FreeBSD)
         ds.shm_perm.mode |= SHM_DEST;
 #endif
         const int ret = shmctl(mShm, IPC_SET, &ds);


### PR DESCRIPTION
SHM_DEST is a non-standard mode used for marking a segment that is to be deleted. No support for this flag on FreeBSD and Darwin.
