### PR TITLE
Added basic travis CI build configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+compiler:
+    - gcc
+
+install:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -qq
+    - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+
+before_script:
+    - mkdir build
+    - cd build
+    - cmake ..
+
+script: make
+
+os:
+    - linux
+    - osx
+


### PR DESCRIPTION
Just like for rtags, this enables basic CI build for rct. For now, sticking with only g++ 4.8 build. From what I can tell, multiple compilers support is being worked on and that will later allow to run multiple builds with various versions of g++/clang++.
