### PR TITLE
Added -std=c++11 to HAVE_CXX11 check

### DIFF
--- a/rct.cmake
+++ b/rct.cmake
@@ -148,6 +148,7 @@ target_link_libraries(rct ${CORESERVICES_LIBRARY} ${COREFOUNDATION_LIBRARY} ${RC
 install(CODE "message(\"Installing rct...\")")
 install(TARGETS rct DESTINATION lib COMPONENT rct EXPORT rct)
 
+set(CMAKE_REQUIRED_FLAGS "-std=c++11")
 check_cxx_source_compiles("
   #include <memory>
   #include <mutex>


### PR DESCRIPTION
Otherwise, clang++ defaults to C++0x it seems.
