### PR TITLE
Epoll compatibility

### DIFF
--- a/rct/EventLoop.cpp
+++ b/rct/EventLoop.cpp
@@ -39,7 +39,7 @@
 // EPOLL compitability hacks.
 // (see: https://github.com/kr/beanstalkd/issues/92).
 #if defined(HAVE_EPOLL)
-#include <linux/version.h>
+#  include <linux/version.h>
 #  if !defined EPOLLRDHUP && LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,17)
      // EPOLLRDHUP exists in the kernel since 2.6.17. Just define it here:
      // (see: https://sourceware.org/bugzilla/show_bug.cgi?id=5040)


### PR DESCRIPTION
EPOLLRDHUP was introduced to kernel 2.6.17, but introduced into glibc headers only later on.
epoll_create1() was introduced to glibc 2.6.27, but can be implemented using the older epoll_create().

This fix makes compilation possible and working as expected on older kernels (and glibc), provided you have at least kernel 2.6.17.

I'm running kernel 2.6.18 and glibc 2.5 (RedHat 5.2).
