### PR TITLE
Use vectors instead of non-standard variable length arrays

### DIFF
--- a/rct/Config.cpp
+++ b/rct/Config.cpp
@@ -1,6 +1,8 @@
 #include "Config.h"
 #include "Log.h"
 
+#include <vector>
+
 List<Config::OptionBase*> Config::sOptions;
 bool Config::sAllowsFreeArgs = false;
 List<Value> Config::sFreeArgs;
@@ -46,7 +48,7 @@ bool Config::parse(int argc, char **argv, const List<Path> &rcFiles)
 
     // ::error() << "parsing" << args;
 
-    char *a[args.size()];
+    std::vector<char*> a{static_cast<size_t>(args.size())};
     for (int i=0; i<args.size(); ++i) {
         a[i] = strdup(args.at(i).constData());
     }
@@ -71,7 +73,7 @@ bool Config::parse(int argc, char **argv, const List<Path> &rcFiles)
 
     while (true) {
         int idx = -1;
-        const int ret = getopt_long(args.size(), a, shortOpts.constData(), options, &idx);
+        const int ret = getopt_long(args.size(), &a[0], shortOpts.constData(), options, &idx);
         switch (ret) {
         case -1:
             goto done;

--- a/rct/Connection.cpp
+++ b/rct/Connection.cpp
@@ -7,6 +7,8 @@
 
 #include "Connection.h"
 
+#include <vector>
+
 Connection::Connection(int version)
     : mPendingRead(0), mPendingWrite(0), mTimeoutTimer(0), mFinishStatus(0),
       mVersion(version), mSilent(false), mIsConnected(false), mWarned(false)
@@ -164,11 +166,11 @@ void Connection::onDataAvailable(const SocketClient::SharedPtr&, Buffer&& buf)
         assert(mPendingRead >= 0);
         if (available < static_cast<unsigned int>(mPendingRead))
             break;
-        char buffer[mPendingRead];
-        const int read = bufferRead(mBuffers, buffer, mPendingRead);
+        std::vector<char> buffer(mPendingRead);
+        const int read = bufferRead(mBuffers, &buffer[0], mPendingRead);
         assert(read == mPendingRead);
         mPendingRead = 0;
-        std::shared_ptr<Message> message = Message::create(mVersion, buffer, read);
+        std::shared_ptr<Message> message = Message::create(mVersion, &buffer[0], read);
         if (message) {
             auto that = shared_from_this();
             if (message->messageId() == FinishMessage::MessageId) {


### PR DESCRIPTION
Hi Anders,

please find attached a patch that replaces use of non-standard variable length arrays with vectors. The trunk version of clang warns when seeing VLAs. The only downside of using vectors is that their memory is likely not allocated on the stack.