### PR TITLE
Add a function to checksum a file by mmap'ing it

### DIFF
--- a/rct/Path.h
+++ b/rct/Path.h
@@ -3,6 +3,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/rct/SHA256.cpp
+++ b/rct/SHA256.cpp
@@ -96,3 +96,24 @@ String SHA256::hash(const char* data, unsigned int size, MapType type)
         return hashToHex(&priv);
     return String(reinterpret_cast<char*>(priv.hash), SHA256_DIGEST_LENGTH);
 }
+
+String SHA256::hashFile(const Path& file, MapType type)
+{
+    int fd = ::open(file.nullTerminated(), 0);
+    if (fd < 0) {
+        return "";
+    }
+
+    int64_t size = file.fileSize();
+    void *mapped = ::mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (mapped == MAP_FAILED) {
+        return "";
+    }
+
+    String ret = SHA256::hash((const char *) mapped, size, type);
+
+    ::munmap(mapped, size);
+    ::close(fd);
+
+    return ret;
+}

--- a/rct/SHA256.h
+++ b/rct/SHA256.h
@@ -2,6 +2,7 @@
 #define SHA256_H
 
 #include <rct/String.h>
+#include <rct/Path.h>
 
 class SHA256Private;
 
@@ -22,6 +23,7 @@ public:
 
     static String hash(const String& data, MapType type = Hex);
     static String hash(const char* data, unsigned int size, MapType type = Hex);
+    static String hashFile(const Path& fileName, MapType type = Hex);
 
 private:
     SHA256Private* priv;


### PR DESCRIPTION
I have a set of changes for rtags that uses checksums to determine file dirtiness instead of mtimes. Checksum-based dirtiness is more accurate than mtime-based, especially when using git and switching branches frequently.

This change is pre-requisite for the rtags change.