### PR TITLE
bug fix: Connections used after being free'd

### DIFF
--- a/rct/Connection.h
+++ b/rct/Connection.h
@@ -97,6 +97,7 @@ public:
 
 private:
     Connection(int version);
+    void disconnect();
     void connect(const SocketClient::SharedPtr &client);
     void onClientConnected(const SocketClient::SharedPtr&) { mIsConnected = true; mConnected(shared_from_this()); }
     void onClientDisconnected(const SocketClient::SharedPtr&) { mIsConnected = false; mDisconnected(shared_from_this()); }


### PR DESCRIPTION
Connections can have their SocketClient callbacks called after they have been
free'd, because the SignalSlot that is holding on to a reference for them isn't
doing it through a shared pointer.  I've got a project that reliably triggers
this behavior in rdm, I think because rp is also crashing and the resulting
SIGPIPE closes down the socket in an unusual way.  Or something.

The patch is to disconnect all the SignalSlots when the Connection is torn down,
to make sure those non-counted references don't stick around.

Connection free'd here:

* thread #1: tid = 0xf7793, 0x00000001000abc94 rdm`Connection::~Connection(this=0x00000001060b6600) + 4 at Connection.cpp:22, queue = 'com.apple.main-thread', stop reason = breakpoint 1.2
  * frame #0: 0x00000001000abc94 rdm`Connection::~Connection(this=0x00000001060b6600) + 4 at Connection.cpp:22
    frame #1: 0x000000010008ab47 rdm`std::__1::__shared_ptr_pointer<Connection*, std::__1::default_delete<Connection>, std::__1::allocator<Connection> >::__on_zero_shared() [inlined] std::__1::default_delete<Connection>::operator(__ptr=0x00000001060b6600)(Connection*) const + 13 at memory:2459
    frame #2: 0x000000010008ab3a rdm`std::__1::__shared_ptr_pointer<Connection*, std::__1::default_delete<Connection>, std::__1::allocator<Connection> >::__on_zero_shared(this=<unavailable>) + 10 at memory:3700
    frame #3: 0x00007fff8b10ecb8 libc++.1.dylib`std::__1::__shared_weak_count::__release_shared() + 44
    frame #4: 0x00000001000ac5fa rdm`Connection::onDataAvailable(std::__1::shared_ptr<SocketClient> const&, Buffer&&) [inlined] std::__1::shared_ptr<Connection>::~shared_ptr() + 1498 at memory:4490
    frame #5: 0x00000001000ac5f2 rdm`Connection::onDataAvailable(std::__1::shared_ptr<SocketClient> const&, Buffer&&) [inlined] std::__1::shared_ptr<Connection>::~shared_ptr() at memory:4488
    frame #6: 0x00000001000ac5f2 rdm`Connection::onDataAvailable(this=0x00000001060b6600, (null)=<unavailable>, buf=0x00000001026c6a28) + 1490 at Connection.cpp:195
    frame #7: 0x00000001000c58b1 rdm`void Signal<std::__1::function<void (std::__1::shared_ptr<SocketClient> const&, Buffer&&)> >::operator()<std::__1::shared_ptr<SocketClient>&, Buffer>(std::__1::shared_ptr<SocketClient>&&&, Buffer&&) [inlined] std::__1::function<void (std::__1::shared_ptr<SocketClient> const&, Buffer&&)>::operator()(std::__1::shared_ptr<SocketClient> const&, Buffer&&) const + 145 at functional:1793
    frame #8: 0x00000001000c5899 rdm`void Signal<std::__1::function<void (std::__1::shared_ptr<SocketClient> const&, Buffer&&)> >::operator(this=<unavailable>, args=0x00007fff5fbfd590, args=0x00000001026c6a28)<std::__1::shared_ptr<SocketClient>&, Buffer>(std::__1::shared_ptr<SocketClient>&&&, Buffer&&) + 121 at SignalSlot.h:69
    frame #9: 0x00000001000c30fa rdm`SocketClient::socketCallback(this=0x00000001026c67a0, f=<unavailable>, mode=<unavailable>) + 1546 at SocketClient.cpp:601
    frame #10: 0x00000001000b2bca rdm`EventLoop::fireSocket(int, unsigned int) [inlined] std::__1::function<void (int, unsigned int)>::operator(__arg=<unavailable>, __arg=<unavailable>)(int, unsigned int) const + 266 at functional:1793
    frame #11: 0x00000001000b2bb0 rdm`EventLoop::fireSocket(this=<unavailable>, fd=<unavailable>, mode=1) + 240 at EventLoop.cpp:684
    frame #12: 0x00000001000b2a17 rdm`EventLoop::processSocketEvents(this=0x000000010270ddf0, events=0x00007fff5fbfd760, eventCount=<unavailable>) + 471 at EventLoop.cpp:823
    frame #13: 0x00000001000b2f6a rdm`EventLoop::exec(this=0x000000010270ddf0, timeoutTime=<unavailable>) + 730 at EventLoop.cpp:941
    frame #14: 0x0000000100006a7f rdm`main(argc=<unavailable>, argv=<unavailable>) + 12239 at rdm.cpp:729
    frame #15: 0x00007fff8dd9f5ad libdyld.dylib`start + 1
    frame #16: 0x00007fff8dd9f5ad libdyld.dylib`start + 1

Then used again here

* thread #1: tid = 0xf7793, 0x00007fff926610ae libsystem_kernel.dylib`__pthread_kill + 10, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007fff926610ae libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff945db665 libsystem_pthread.dylib`pthread_kill + 90
    frame #2: 0x00007fff9a6793fb libsystem_c.dylib`abort + 129
    frame #3: 0x00007fff90d50f81 libc++abi.dylib`abort_message + 257
    frame #4: 0x00007fff90d7696a libc++abi.dylib`default_terminate_handler() + 46
    frame #5: 0x00007fff90d7419e libc++abi.dylib`std::__terminate(void (*)()) + 8
    frame #6: 0x00007fff90d7422d libc++abi.dylib`std::terminate() + 77
    frame #7: 0x00000001000adb13 rdm`Connection::onClientDisconnected(std::__1::shared_ptr<SocketClient> const&) + 147 at Connection.cpp:34
    frame #8: 0x00000001000adb0e rdm`Connection::onClientDisconnected(this=<unavailable>, (null)=<unavailable>) + 142 at Connection.h:110
    frame #9: 0x00000001000c547e rdm`void Signal<std::__1::function<void (std::__1::shared_ptr<SocketClient> const&)> >::operator()<std::__1::shared_ptr<SocketClient>&>(std::__1::shared_ptr<SocketClient>&&&) [inlined] std::__1::function<void (std::__1::shared_ptr<SocketClient> const&)>::operator()(std::__1::shared_ptr<SocketClient> const&) const + 142 at functional:1793
    frame #10: 0x00000001000c5469 rdm`void Signal<std::__1::function<void (std::__1::shared_ptr<SocketClient> const&)> >::operator(this=<unavailable>, args=0x00007fff5fbfd590)<std::__1::shared_ptr<SocketClient>&>(std::__1::shared_ptr<SocketClient>&&&) + 121 at SignalSlot.h:69
    frame #11: 0x00000001000c310a rdm`SocketClient::socketCallback(this=0x00000001026c67a0, f=<unavailable>, mode=<unavailable>) + 1562 at SocketClient.cpp:603
    frame #12: 0x00000001000b2bca rdm`EventLoop::fireSocket(int, unsigned int) [inlined] std::__1::function<void (int, unsigned int)>::operator(__arg=<unavailable>, __arg=<unavailable>)(int, unsigned int) const + 266 at functional:1793
    frame #13: 0x00000001000b2bb0 rdm`EventLoop::fireSocket(this=<unavailable>, fd=<unavailable>, mode=1) + 240 at EventLoop.cpp:684
    frame #14: 0x00000001000b2a17 rdm`EventLoop::processSocketEvents(this=0x000000010270ddf0, events=0x00007fff5fbfd760, eventCount=<unavailable>) + 471 at EventLoop.cpp:823
    frame #15: 0x00000001000b2f6a rdm`EventLoop::exec(this=0x000000010270ddf0, timeoutTime=<unavailable>) + 730 at EventLoop.cpp:941
    frame #16: 0x0000000100006a7f rdm`main(argc=<unavailable>, argv=<unavailable>) + 12239 at rdm.cpp:729
    frame #17: 0x00007fff8dd9f5ad libdyld.dylib`start + 1
    frame #18: 0x00007fff8dd9f5ad libdyld.dylib`start + 1

Signed-off-by: Lawrence D'Anna <larry@elder-gods.org>