### PR TITLE
Use POSIX api to determine timezone offset [Fixed].

### DIFF
--- a/rct/Date.cpp
+++ b/rct/Date.cpp
@@ -1,5 +1,6 @@
 #include "Date.h"
 #include <mutex>
+#include <iostream>
 
 static std::once_flag tzFlag;
 
@@ -29,7 +30,7 @@ void Date::setTime(time_t time, Mode mode)
         mTime = time;
     else {
         struct tm ltime;
-        if (!modetime(time, &ltime, mode)) {
+        if (modetime(time, &ltime, mode)) {
             mTime = time + ltime.tm_gmtoff;
         }
     }

--- a/rct/Date.cpp
+++ b/rct/Date.cpp
@@ -27,8 +27,12 @@ void Date::setTime(time_t time, Mode mode)
         });
     if (mode == UTC)
         mTime = time;
-    else
-        mTime = time + timezone;
+    else {
+        struct tm ltime;
+        if (!modetime(time, &ltime, mode)) {
+            mTime = time + ltime.tm_gmtoff;
+        }
+    }
 }
 
 int Date::date(Mode mode) const


### PR DESCRIPTION
Current approach doesn't work on BSDs, as ```timezone``` is not a global long there but rather a function, as a result compilation failure due to an attempt to add function to a ```time_t```. Instead, proposing usage of localtime_r to figure out what is the timezone offset, which is portable.