### PR TITLE
Added a base for unit tests and a sample unit test for Date::setTime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,7 @@ include(rct.cmake)
 # add_executable(dbtest rct/dbtest.cpp)
 # target_link_libraries(dbtest rct)
 
-
+if (WITH_TESTS)
+    add_subdirectory(tests)
+endif ()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(rct_tests C CXX)
+
+include(FindPkgConfig)
+pkg_search_module(CPPUNIT REQUIRED cppunit)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPPUNIT_CFLAGS}")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Weffc++ -frtti")
+
+add_definitions(
+    ${CPPUNIT_CFLAGS_OTHER}
+)
+
+include_directories(
+    ${PROJECT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CPPUNIT_INCLUDEDIR}
+)
+
+file(GLOB UNIT_TESTS_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+link_directories(${CPPUNIT_LIBRARY_DIRS} ${PROJECT_BINARY_DIR})
+
+set(BINARY_NAME "rct_tests")
+add_executable(${BINARY_NAME} ${UNIT_TESTS_SRCS})
+target_link_libraries(${BINARY_NAME} ${CPPUNIT_LIBRARIES} rct)

--- a/tests/DateTestSuite.cpp
+++ b/tests/DateTestSuite.cpp
@@ -1,0 +1,48 @@
+#include <DateTestSuite.h>
+#include <rct/Date.h>
+
+void
+DateTestSuite::setUp()
+{
+}
+
+void
+DateTestSuite::tearDown()
+{
+}
+
+void
+DateTestSuite::testSetTimeUTC()
+{
+	// prepare
+	Date d;
+
+    CPPUNIT_ASSERT_EQUAL(static_cast<time_t>(0), d.time());
+
+	const time_t now = time(0);
+
+	// execute
+	d.setTime(now, Date::Mode::UTC);
+
+	// verify
+	CPPUNIT_ASSERT_EQUAL(now, d.time());
+}
+
+void
+DateTestSuite::testSetTimeLocalTZ()
+{
+	// prepare
+	Date d;
+
+    CPPUNIT_ASSERT_EQUAL(static_cast<time_t>(0), d.time());
+
+	const time_t now = time(0);
+
+	// execute
+	d.setTime(now, Date::Mode::Local);
+
+	// verify
+    struct tm ltime;
+    localtime_r(&now, &ltime);
+	CPPUNIT_ASSERT_EQUAL(now + ltime.tm_gmtoff, d.time());
+}

--- a/tests/DateTestSuite.h
+++ b/tests/DateTestSuite.h
@@ -1,0 +1,23 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+class DateTestSuite : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(DateTestSuite);
+
+    CPPUNIT_TEST(testSetTimeUTC);
+    CPPUNIT_TEST(testSetTimeLocalTZ);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp();
+        void tearDown();
+
+    protected:
+        void testSetTimeUTC();
+        void testSetTimeLocalTZ();
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(DateTestSuite);
+

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,115 @@
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include <cppunit/TestResult.h>
+#include <cppunit/TestResultCollector.h>
+#include <cppunit/TestFailure.h>
+#include <cppunit/CompilerOutputter.h>
+
+#include <algorithm>
+#include <iostream>
+
+class CustomOutputter : public CppUnit::CompilerOutputter
+{
+    public:
+        CustomOutputter(CppUnit::TestResultCollector* iResults,
+                        CppUnit::OStream& iStream,
+                        const std::string& iLocationFormat = CPPUNIT_COMPILER_LOCATION_FORMAT)
+            : CppUnit::CompilerOutputter(iResults, iStream, iLocationFormat),
+              m_result(iResults),
+              m_stream(iStream)
+        {}
+
+        virtual void write()
+        {
+            CppUnit::CompilerOutputter::write();
+
+            using namespace CppUnit;
+            // use because TestFailures holds TestFailure* instead of Test*;
+            // \fixme Find better solution to detect whether the test case failed or not
+            std::set<const Test*> failed;
+            TestResultCollector::TestFailures::const_iterator fIter = m_result->failures().begin();
+            TestResultCollector::TestFailures::const_iterator fEnd = m_result->failures().end();
+
+            for (; fIter != fEnd; ++fIter) {
+                failed.insert((*fIter)->failedTest());
+            }
+
+            std::string pass = "[32mPASS[0m";
+            std::string fail = "[31mFAIL[0m";
+
+            TestResultCollector::Tests::const_iterator iter = m_result->tests().begin();
+            TestResultCollector::Tests::const_iterator end = m_result->tests().end();
+
+            std::string testName;
+            std::string suiteName;
+            std::string caseName;
+            std::string lastTestSuiteName;
+            for (; iter != end; ++iter) {
+                // split test name into suite name and case name
+                testName = (*iter)->getName();
+                suiteName = testName.substr(0, testName.find("::"));
+                caseName = testName.substr(testName.find("::") + 2);
+
+                // if new test suite is observed, print its name
+                if (suiteName != lastTestSuiteName) {
+                    m_stream << std::endl << suiteName << std::endl;
+                    lastTestSuiteName = suiteName;
+                }
+
+                m_stream << "[ ";
+                if (failed.end() != failed.find(*iter)) {
+                    m_stream << fail;
+                } else {
+                    m_stream << pass;
+                }
+
+
+
+                m_stream << " ] " << caseName << std::endl;
+            }
+            m_stream << std::endl;
+
+            /** STATS **/
+            int numErrors = m_result->testErrors();
+            int numFailures = m_result->testFailures();
+            int numFailuresTotal = m_result->testFailuresTotal();
+            int numTests = m_result->runTests();
+
+            m_stream << "============================================================" << std::endl;
+            m_stream << " STATISTICS" << std::endl;
+            m_stream << "============================================================" << std::endl;
+            m_stream << "Number of errors (uncaught exception):  " << numErrors << std::endl;
+            m_stream << "Number of failures (failed assertions): " << numFailures << std::endl;
+            m_stream << "Total number of detected failures:      " << numFailuresTotal << std::endl;
+            m_stream << "Total number of tests:                  " << numTests << std::endl;
+            m_stream << "============================================================" << std::endl;
+        }
+
+    private:
+        CppUnit::TestResultCollector* m_result;
+        CppUnit::OStream& m_stream;
+
+};
+
+
+int main(int argc, char* argv[])
+{
+    CppUnit::TestRunner runner;
+
+    CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry();
+
+    runner.addTest( registry.makeTest() );
+
+    CppUnit::TestResult controller;
+    CppUnit::TestResultCollector result;
+    controller.addListener(&result);
+
+    runner.run(controller);
+
+    CustomOutputter outputter(&result, std::cerr);
+
+    outputter.write();
+
+    return result.wasSuccessful() ? 0 : 1;
+}
+


### PR DESCRIPTION
While preparing previous pull request noticed that unit tests were lacking. Proposing this skeleton for unit tests based on cppunit. Would encourage all developers contributing to this library to add tests for newly added functionality, as well as any functionality that is being modified/extended.
By default, the build doesn't compile unit tests. To compile tests configure cmake with
```
cmake -DWITH_TESTS=1 ..
```
and run unit tests with
```
<builddir>/tests/rct_tests
```