### PR TITLE
Removing fallback case for setting time.

### DIFF
--- a/rct/Date.cpp
+++ b/rct/Date.cpp
@@ -33,8 +33,6 @@ void Date::setTime(time_t time, Mode mode)
         struct tm ltime;
         if (modetime(time, &ltime, mode)) {
             mTime = time + ltime.tm_gmtoff;
-        } else {
-            mTime += timezone;
         }
     }
 }

--- a/rct/Date.cpp
+++ b/rct/Date.cpp
@@ -11,6 +11,7 @@ Date::Date()
 }
 
 Date::Date(time_t time, Mode mode)
+    : Date()
 {
     setTime(time, mode);
 }


### PR DESCRIPTION
As discussed for commit f61e3a0d196a2f193c77896d61647f43de82e666 removing the fallback. Also adding constructor delegation which will ensure mTime is either 0 or the value representing time.