### PR TITLE
Generate profile/coverage data and add a target to generate coverage report.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,12 @@ if (WITH_TESTS)
             gcov48
         )
 
+        add_custom_target(
+            gen_llvm_cov_wrapper_script
+            COMMAND true
+            VERBATIM
+        )
+
         set(GCOV_TOOL GCOV_EXECUTABLE)
     endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,13 @@
 cmake_minimum_required(VERSION 2.8)
+
+# If building with tests, set flags to generate profile/coverage data
+# for the compilation of the main code.
+if (WITH_TESTS)
+    SET(CMAKE_CXX_FLAGS "-g -O0 -Wall -fprofile-arcs -ftest-coverage")
+    SET(CMAKE_C_FLAGS "-g -O0 -Wall -W -fprofile-arcs -ftest-coverage")
+    SET(CMAKE_EXE_LINKER_FLAGS "-fprofile-arcs -ftest-coverage")
+endif ()
+
 include(rct.cmake)
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
@@ -14,5 +23,46 @@ include(rct.cmake)
 if (WITH_TESTS)
     enable_testing()
     add_subdirectory(tests)
+
+    if (${CMAKE_CXX_COMPILER} MATCHES "clang")
+        find_program(LLVM_COV_EXECUTABLE
+            NAMES
+            llvm-cov
+            llvm-cov35
+            llvm-cov36
+            llvm-cov37
+            )
+
+        add_custom_target(
+            gen_llvm_cov_wrapper_script
+            COMMAND echo ${LLVM_COV_EXECUTABLE} gcov $@ | tee llvm-cov.sh
+            COMMAND chmod a+x llvm-cov.sh
+            VERBATIM
+        )
+
+        set(GCOV_TOOL ./llvm-cov.sh)
+    else ()
+        find_program(GCOV_EXECUTABLE
+            NAMES
+            gcov47
+            gcov48
+        )
+
+        set(GCOV_TOOL GCOV_EXECUTABLE)
+    endif ()
+
+    find_program(LCOV_EXECUTABLE NAMES lcov)
+    find_program(GENHTML_EXECUTABLE NAMES genhtml)
+
+    if (GCOV_TOOL AND LCOV_EXECUTABLE AND GENHTML_EXECUTABLE)
+        add_custom_target(
+            coverage
+            COMMAND ${LCOV_EXECUTABLE} --directory . --base-directory . --gcov-tool ${GCOV_TOOL} -capture -o cov.info
+            COMMAND ${GENHTML_EXECUTABLE} cov.info -o output
+            DEPENDS gen_llvm_cov_wrapper_script
+            VERBATIM
+        )
+    endif ()
+
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if (WITH_TESTS)
             VERBATIM
         )
 
-        set(GCOV_TOOL GCOV_EXECUTABLE)
+        set(GCOV_TOOL ${GCOV_EXECUTABLE})
     endif ()
 
     find_program(LCOV_EXECUTABLE NAMES lcov)


### PR DESCRIPTION
As next step to getting tested code I'm proposing this change which generates profile and coverage data for the code. It does so only when building `WITH_TESTS` so that it doesn't affect library consumers. Corresponding flags are being passed to the compiler/linker and after tests are executed a coverage can be generated using `lcov` tool.
With this change 2 new targets are introduced: `gen_llvm_cov_wrapper_script` and `coverage`.
`gen_llvm_cov_wrapper_script` is a helper target and generates a wrapper for `llvm-cov` utility so that `lcov` can use it. `coverage` target is the main target that generates report in `<build_dir>/output`.

Sample workflow:

```
$ mkdir build
$ cd build
$ cmake -DCMAKE_CXX_COMPILER=clang++ -DWITH_TESTS=1 ..
$ make
$ make test
$ make coverage
$ <browser> output/index.html
```

CMake tries to locate all tools that are required for test coverage report. For now added binary names as they appear on FreeBSD, Linux name alternatives may/should be added to the list when invoking `find_program`.
