### PR TITLE
Fix to build on FreeBSD.

### DIFF
--- a/rct/FileSystemWatcher.h
+++ b/rct/FileSystemWatcher.h
@@ -52,6 +52,7 @@ public:
 private:
     void init();
     void shutdown();
+    void destroy();
 #if defined(HAVE_FSEVENTS) || defined(HAVE_CHANGENOTIFICATION)
     WatcherData* mWatcher;
     friend class WatcherData;

--- a/rct/FileSystemWatcher_kqueue.cpp
+++ b/rct/FileSystemWatcher_kqueue.cpp
@@ -38,6 +38,9 @@ void FileSystemWatcher::destroy()
     close(mFd);
 }
 
+// TODO What is the proper way to shut down?
+void FileSystemWatcher::shutdown() {}
+
 struct FSUserData
 {
     Set<Path> all, added, modified;


### PR DESCRIPTION
These changes allow rtags to build on FreeBSD 10. I'm not certain how to properly implement FileSystemWatcher::shutdown() so I left the function definition empty.