### PR TITLE
Make Path::isSource return true for .c++ extension

### DIFF
--- a/rct/Path.cpp
+++ b/rct/Path.cpp
@@ -263,7 +263,7 @@ const char * Path::extension(int *len) const
 
 bool Path::isSource(const char *ext)
 {
-    const char *sources[] = { "c", "cc", "cpp", "cxx", "moc", "mm", "m", 0 };
+    const char *sources[] = { "c", "cc", "cpp", "cxx", "c++", "moc", "mm", "m", 0 };
     for (int i=0; sources[i]; ++i) {
         if (!strcasecmp(ext, sources[i]))
             return true;


### PR DESCRIPTION
[Cap'n Proto](git@github.com:sandstorm-io/capnproto.git) uses the .c++ extension for its source files, which seems to trip up RTags.  This commit adds this extension to the isSource whitelist.  (And I've verified that this does appear to resolve the problem.)

Anyway, so far I'm a huge fan of RTags.  Thanks for all your work!