### PR TITLE
Fix a build break - Win32 filesystem watcher also uses shared_ptr.

### DIFF
--- a/rct/FileSystemWatcher_win32.cpp
+++ b/rct/FileSystemWatcher_win32.cpp
@@ -76,7 +76,7 @@ void WatcherSlice::run()
     }
 }
 
-class WatcherData
+class WatcherData : public std::enable_shared_from_this<WatcherData> 
 {
 public:
     WatcherData(FileSystemWatcher* w)
@@ -313,7 +313,7 @@ void WatcherData::stop()
 
 void FileSystemWatcher::init()
 {
-    mWatcher = new WatcherData(this);
+    mWatcher.reset(new WatcherData(this));
     mWatcher->wakeupHandle = CreateEvent(NULL, FALSE, FALSE, NULL);
     mWatcher->thread = std::thread(std::bind(&WatcherData::run, mWatcher));
 }
@@ -322,7 +322,7 @@ void FileSystemWatcher::shutdown()
 {
     mWatcher->stop();
     CloseHandle(mWatcher->wakeupHandle);
-    delete mWatcher;
+    mWatcher.reset();
 }
 
 void FileSystemWatcher::clear()


### PR DESCRIPTION
6efe7a07c2d708d10832485067ac8916087b240a changed FileSystemWatcher_fsevents.cpp, but missed updating the Win32 code breaking the build on Windows. This change switches the Win32 code over to using shared_ptr as well.

CallLaterMove _may_ also need to be updated in the same way as the fsevents code, and I haven't actually run the change, this just gets things building.