### PR TITLE
Fix timeout with Process::exec()

### DIFF
--- a/rct/Process.cpp
+++ b/rct/Process.cpp
@@ -28,6 +28,9 @@ class ProcessThread : public Thread
 public:
     static void installProcessHandler();
     static void addPid(pid_t pid, Process* process, bool async);
+
+    /// Remove a pid that was previously added with addPid().
+    static void removePid(pid_t pid);
     static void shutdown();
     static void setPending(int pending);
 
@@ -40,6 +43,12 @@ private:
         Child,
         Stop
     };
+
+    /**
+     * Wakeup the listening thread, either because we are to be destructed from
+     * the static destructor, or because a child has terminated (sending
+     * SIGCHLD).
+     */
     static void wakeup(Signal sig);
 
     static void processSignalHandler(int sig);
@@ -122,6 +131,18 @@ void ProcessThread::addPid(pid_t pid, Process* process, bool async)
         sPendingPids.clear();
 }
 
+void ProcessThread::removePid(pid_t f_pid)
+{
+    std::lock_guard<std::mutex> lock(sProcessMutex);
+
+    auto it = sProcesses.find(f_pid);
+    if(it != sProcesses.end())
+    {
+        it->second.proc = nullptr;
+        it->second.loop = EventLoop::SharedPtr();
+    }
+}
+
 void ProcessThread::run()
 {
     ssize_t r;
@@ -137,7 +158,7 @@ void ProcessThread::run()
                 std::unique_lock<std::mutex> lock(sProcessMutex);
                 bool done = false;
                 do {
-                    //printf("testing pid %d\n", proc->first);
+                    // find out which process we're waking up on
                     eintrwrap(p, ::waitpid(0, &ret, WNOHANG));
                     switch(p) {
                     case 0:
@@ -153,13 +174,15 @@ void ProcessThread::run()
                         break;
                     default:
                         //printf("successfully waited for pid (got %d)\n", p);
+                        // child process with pid=p just exited.
                         if (WIFEXITED(ret)) {
                             ret = WEXITSTATUS(ret);
                         } else {
                             ret = Process::ReturnCrashed;
                         }
+                        // find the process object to this child process
                         auto proc = sProcesses.find(p);
-                        if (proc != sProcesses.end()) {
+                        if (proc != sProcesses.end() && proc->second.proc != nullptr) {
                             Process *process = proc->second.proc;
                             EventLoop::SharedPtr loop = proc->second.loop.lock();
                             sProcesses.erase(proc++);
@@ -557,6 +580,14 @@ Process::ExecState Process::startInternal(const Path &command, const List<String
                     if (lasted >= timeout) {
                         // timeout, we're done
                         kill(); // attempt to kill
+
+                        // we need to remove this Process object from
+                        // ProcessThread, because ProcessThread will try to
+                        // finish() this object. However, this object may
+                        // already have been deleted *before* ProcessThread
+                        // runs, creating a segfault.
+                        ProcessThread::removePid(mPid);
+
                         mErrorString = "Timed out";
                         return TimedOut;
                     }

--- a/rct/Process.cpp
+++ b/rct/Process.cpp
@@ -182,17 +182,19 @@ void ProcessThread::run()
                         }
                         // find the process object to this child process
                         auto proc = sProcesses.find(p);
-                        if (proc != sProcesses.end() && proc->second.proc != nullptr) {
+                        if (proc != sProcesses.end()) {
                             Process *process = proc->second.proc;
-                            EventLoop::SharedPtr loop = proc->second.loop.lock();
-                            sProcesses.erase(proc++);
-                            lock.unlock();
-                            if (loop) {
-                                loop->callLater([process, ret]() { process->finish(ret); });
-                            } else {
-                                process->finish(ret);
+                            if(process != nullptr) {
+                                EventLoop::SharedPtr loop = proc->second.loop.lock();
+                                sProcesses.erase(proc++);
+                                lock.unlock();
+                                if (loop) {
+                                    loop->callLater([process, ret]() { process->finish(ret); });
+                                } else {
+                                    process->finish(ret);
+                                }
+                                lock.lock();
                             }
-                            lock.lock();
                         } else {
                             if (sPending) {
                                 assert(sPendingPids.find(p) == sPendingPids.end());

--- a/rct/Process.cpp
+++ b/rct/Process.cpp
@@ -489,12 +489,11 @@ Process::ExecState Process::startInternal(const Path &command, const List<String
             }
         } else {
             // select and stuff
-            timeval started, now, *selecttime = 0;
+            timeval started, now, timeoutForSelect;
             if (timeout > 0) {
                 Rct::gettime(&started);
-                now = started;
-                selecttime = &now;
-                Rct::timevalAdd(selecttime, timeout);
+                timeoutForSelect.tv_sec = timeout / 1000;
+                timeoutForSelect.tv_usec = (timeout % 1000) * 1000;
             }
             if (!(execFlags & NoCloseStdIn)) {
                 closeStdIn(CloseForce);
@@ -517,7 +516,7 @@ Process::ExecState Process::startInternal(const Path &command, const List<String
                     max = std::max(max, mStdIn[1]);
                 }
                 int ret;
-                eintrwrap(ret, ::select(max + 1, &rfds, &wfds, 0, selecttime));
+                eintrwrap(ret, ::select(max + 1, &rfds, &wfds, 0, &timeoutForSelect));
                 if (ret == -1) { // ow
                     mErrorString = "Sync select failed: ";
                     mErrorString += Rct::strerror();
@@ -551,17 +550,21 @@ Process::ExecState Process::startInternal(const Path &command, const List<String
                     return Done;
                 }
                 if (timeout) {
-                    assert(selecttime);
-                    Rct::gettime(selecttime);
-                    const int lasted = Rct::timevalDiff(selecttime, &started);
+                    Rct::gettime(&now);
+
+                    // lasted is the amount of time we spent until now in ms
+                    const int lasted = Rct::timevalDiff(&now, &started);
                     if (lasted >= timeout) {
                         // timeout, we're done
                         kill(); // attempt to kill
                         mErrorString = "Timed out";
                         return TimedOut;
                     }
-                    *selecttime = started;
-                    Rct::timevalAdd(selecttime, timeout);
+
+                    // (timeout - lasted) is guaranteed to be > 0 because of
+                    // the check above.
+                    timeoutForSelect.tv_sec = (timeout - lasted) / 1000;
+                    timeoutForSelect.tv_usec = ((timeout - lasted) % 1000) * 1000;
                 }
             }
         }


### PR DESCRIPTION
While porting rct's Process class to windows, I found some problems with the timeout argument to Process::exec():

- `Process::startInternal()` calculated `::select()`'s timeout value by taking the current time and adding the `timeout` parameter. However, `::select()` does not expect a time point as timeout, but just the timeout value. As a result, `Process::exec()` would never return, even if a timeout was set.
- Additionally, there was a race condition when the Process object that started a child process with a timeout was deleted (e.g., by going out of scope) before the parent process received the `SIGCHLD` signal. Upon receiving the signal, `ProcessThread` would try to call methods on the already deleted `Process` object, leading to random segfaults.

This pull request fixes both problems and adds a few comments.

There are some test cases for Process on my `win` branch:
- Commit `1a6d780d` contains the test case `ProcessTestSuite::execTimeout()` which hangs forever
- Commit `e4537a29` fixes the timeout calculation: The test case does not hang anymore, but exhibits random segfaults.
- Commit `ece79509` is on the same level as this pull request: The tests pass on time and there are no more segfaults.
