### PR TITLE
Fix a compilation error in FreeBSD 11.0-p1

### DIFF
--- a/rct/EventLoop.h
+++ b/rct/EventLoop.h
@@ -16,9 +16,9 @@
 #if defined(HAVE_EPOLL)
 #  include <sys/epoll.h>
 #elif defined(HAVE_KQUEUE)
+#  include <sys/types.h>
 #  include <sys/event.h>
 #  include <sys/time.h>
-#  include <sys/types.h>
 #elif defined(HAVE_SELECT)
 #  include <sys/select.h>
 #endif


### PR DESCRIPTION
There was an error compiling in the current FreeBSD stable version:

```
david@freebsd:~/workspace/rct % uname -a
FreeBSD freebsd 11.0-RELEASE-p1 FreeBSD 11.0-RELEASE-p1 #0 r306420: Thu Sep 29 01:43:23 UTC 2016     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC  amd64
david@freebsd:~/workspace/rct % make
Scanning dependencies of target rct
[  3%] Building CXX object CMakeFiles/rct.dir/rct/AES256CBC.cpp.o
[  6%] Building CXX object CMakeFiles/rct.dir/rct/SHA256.cpp.o
[ 10%] Building CXX object CMakeFiles/rct.dir/rct/Buffer.cpp.o
[ 13%] Building CXX object CMakeFiles/rct.dir/rct/Config.cpp.o
[ 16%] Building CXX object CMakeFiles/rct.dir/rct/Connection.cpp.o
[ 20%] Building CXX object CMakeFiles/rct.dir/rct/CpuUsage.cpp.o
[ 23%] Building CXX object CMakeFiles/rct.dir/rct/Date.cpp.o
[ 26%] Building CXX object CMakeFiles/rct.dir/rct/EventLoop.cpp.o
In file included from /usr/home/david/workspace/rct/rct/EventLoop.cpp:1:
In file included from /usr/home/david/workspace/rct/rct/EventLoop.h:19:
/usr/include/sys/event.h:61:2: error: unknown type name 'u_short'; did you mean 'short'?
        u_short         flags;
        ^
/usr/include/sys/event.h:62:2: error: unknown type name 'u_int'
        u_int           fflags;
        ^
2 errors generated.
*** Error code 1

Stop.
make[2]: stopped in /usr/home/david/workspace/rct
*** Error code 1

Stop.
make[1]: stopped in /usr/home/david/workspace/rct
*** Error code 1

Stop.
make: stopped in /usr/home/david/workspace/rct
david@freebsd:~/workspace/rct %
```