### PR TITLE
Capture by reference instead of by value.

### DIFF
--- a/rct/EventLoop.cpp
+++ b/rct/EventLoop.cpp
@@ -841,7 +841,7 @@ unsigned int EventLoop::exec(int timeoutTime)
 {
     int quitTimerId = -1;
     if (timeoutTime != -1)
-        quitTimerId = registerTimer([=](int) { mTimeout = true; quit(); }, timeoutTime, Timer::SingleShot);
+        quitTimerId = registerTimer([&](int) { mTimeout = true; quit(); }, timeoutTime, Timer::SingleShot);
 
     unsigned int ret = 0;
 


### PR DESCRIPTION
callback for registerTimer should capture by reference instead of value.