### PR TITLE
List::remove(): Bugfix

### DIFF
--- a/rct/List.h
+++ b/rct/List.h
@@ -323,7 +323,7 @@ public:
         typename Base::iterator it = Base::begin();
         while (it != Base::end()) {
             if (match(*it)) {
-                Base::erase(it++);
+                Base::erase(it);
                 ++ret;
             } else {
                 ++it;


### PR DESCRIPTION
Don't move to next element after removing a single element.

When erasing an element, the "next" element takes the place of the removed element. If you increment `it`, you will not check this "next" element for removal.