### PR TITLE
Fix compilation for g++ (libstdc++) 7.0

### DIFF
--- a/rct.cmake
+++ b/rct.cmake
@@ -235,6 +235,7 @@ if (ASAN)
 endif ()
 
 check_cxx_source_compiles("
+  #include <functional>
   #include <memory>
   #include <mutex>
   #include <tuple>

--- a/rct/EventLoop.h
+++ b/rct/EventLoop.h
@@ -1,6 +1,7 @@
 #ifndef EVENTLOOP_H // -*- mode:c++ -*-
 #define EVENTLOOP_H
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
When using gcc 7.0 (fedora rawhide) cmake currently fails with:
```
CMake Error at rct.cmake:257 (message):
  C++11 support not detected.  rct requires a modern compiler, GCC >= 4.8 or
  Clang >= 3.2 should suffice
```
and after fixing this compilation fails with:
```
In file included from ~/Code/src/rct/rct/EventLoop.cpp:1:0:
~/Code/src/rct/rct/EventLoop.h:145:57: error: ‘std::function’ has not been declared
     bool registerSocket(int fd, unsigned int mode, std::function<void(int, unsigned int)>&& func);
```

We need to explicitly include the functional header for std::function
and std::placeholders::*.