### PR TITLE
Solved compatibility issues for clang on windows

### DIFF
--- a/compiler.cmake
+++ b/compiler.cmake
@@ -20,8 +20,10 @@ else ()
   if (NOT CMAKE_SYSTEM_NAME MATCHES "CYGWIN")
     # Use pic instead of PIC, which produces faster and smaller code,
     # but could eventully lead to linker problems.
-    set(CMAKE_CXX_COMPILE_OPTIONS_PIC  "-fpic")
-    set(CMAKE_C_COMPILE_OPTIONS_PIC  "-fpic")
+    if(NOT WIN32)
+      set(CMAKE_CXX_COMPILE_OPTIONS_PIC  "-fpic")
+      set(CMAKE_C_COMPILE_OPTIONS_PIC  "-fpic")
+    endif()
   endif ()
   if (RCT_USE_LIBCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")

--- a/compiler.cmake
+++ b/compiler.cmake
@@ -1,10 +1,10 @@
 include(CheckCXXCompilerFlag)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpointer-arith -Wnon-virtual-dtor -Wshadow -Wformat")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpointer-arith -Wnon-virtual-dtor -Wshadow -Wformat -pthread")
 if (NOT RCT_RTTI_ENABLED)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif ()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpointer-arith -Wshadow -Wformat")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpointer-arith -Wshadow -Wformat -pthread")
 if (CMAKE_SYSTEM_NAME MATCHES "CYGWIN")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")


### PR DESCRIPTION
- explicitly added `-pthread` flag. unlike gcc, clang on windows needs the flag to be explicitly passed.
- excluded `-fpic` flag. Windows does not require this flag and clang throws an error when passed.