### PR TITLE
Fixed invalid conversion error on win32

### DIFF
--- a/rct/SocketClient.cpp
+++ b/rct/SocketClient.cpp
@@ -356,7 +356,7 @@ void SocketClient::setMulticastTTL(unsigned char ttl)
 }
 
 #ifdef _WIN32
-typedef int (*GetNameFunc)(SOCKET, sockaddr*, socklen_t*);
+typedef int __stdcall (*GetNameFunc)(SOCKET, sockaddr*, socklen_t*);
 #else
 typedef int (*GetNameFunc)(int, sockaddr*, socklen_t*);
 #endif


### PR DESCRIPTION
Building with MinGW 64 (gcc version 5.3.0) I've got the following error:

    SocketClient.cpp: In member function 'String SocketClient::peerName(uint16_t*) const':

    SocketClient.cpp:394:50: error: invalid conversion from 'int (__attribute__((__stdcall__)) *)(SOCKET, sockaddr*, int*) {aka int (__attribute__((__stdcall__)) *)(unsigned int, sockaddr*, int*)}' to 'GetNameFunc {aka int (*)(unsigned int, sockaddr*, int*)}' [-fpermissive]

         return getNameHelper(mFd, ::getpeername, port);

                                                      ^

    SocketClient.cpp:363:22: note:   initializing argument 2 of 'String getNameHelper(int, GetNameFunc, uint16_t*)'

     static inline String getNameHelper(int mFd, GetNameFunc func, uint16_t* port)

                          ^

    SocketClient.cpp: In member function 'String SocketClient::sockName(uint16_t*) const':

    SocketClient.cpp:401:50: error: invalid conversion from 'int (__attribute__((__stdcall__)) *)(SOCKET, sockaddr*, int*) {aka int (__attribute__((__stdcall__)) *)(unsigned int, sockaddr*, int*)}' to 'GetNameFunc {aka int (*)(unsigned int, sockaddr*, int*)}' [-fpermissive]

         return getNameHelper(mFd, ::getsockname, port);

                                                      ^

    SocketClient.cpp:363:22: note:   initializing argument 2 of 'String getNameHelper(int, GetNameFunc, uint16_t*)'

     static inline String getNameHelper(int mFd, GetNameFunc func, uint16_t* port)

                          ^

    ninja: build stopped: subcommand failed.

Prepending `__stdcall` to `GetNameFunc` solves the problem.
