### PR TITLE
Support for libc2.5

### DIFF
--- a/rct/FileSystemWatcher_inotify.cpp
+++ b/rct/FileSystemWatcher_inotify.cpp
@@ -13,8 +13,11 @@
 
 void FileSystemWatcher::init()
 {
-    mFd = inotify_init1(IN_CLOEXEC);
+    mFd = inotify_init();
     assert(mFd != -1);
+    int res = fcntl(mFd, F_SETFD, FD_CLOEXEC);
+    std::ignore = res;
+    assert(res != -1);
     EventLoop::eventLoop()->registerSocket(mFd, EventLoop::SocketRead, std::bind(&FileSystemWatcher::notifyReadyRead, this));
 }
 


### PR DESCRIPTION
For unspeakable reasons I need to be able to build and run rtags (and consequently rct) in a libc2.5 environment. The `inotify_init1` symbol does exist in libc2.5.

This diff replaces the `init1(IN_CLOEXEC)` call with a `inotify_init` call followed by `fcntl` to set CLOEXEC.  This got it working with libc2.5

It would be convenient to have this merged to the mainstream, rather than reapply this patch when I next need to build it, but there might be some concerns:
1. It's an extra syscall
2. (maybe more important) if you don't require the callers of `init()` to not exec in a separate thread while `init` is getting run, then it is possible that a file descriptor gets leaked, since CLOEXEC is not set at `open` time.

If (2) is a real concern, then I can just re-apply this patch if I need to rebuild.