### PR TITLE
patch to fix rtags #1202 issue

### DIFF
--- a/rct/Path.cpp
+++ b/rct/Path.cpp
@@ -476,7 +476,13 @@ bool Path::mkdir(const Path &path, MkDirMode mkdirMode, mode_t permissions)
 #else
             const int r = ::mkdir(buf, permissions);
 #endif
-            if (r && errno != EEXIST && errno != EISDIR)
+            if (r && errno != EEXIST && errno != EISDIR
+#ifdef OS_CYGWIN
+            		// on cygwin/msys2 we may try to create something like (/cygdrive)/c/some/path/
+            		// an mkdir() attempt to create /c/ will fail with EACCESS so we need to catch it here
+            		&& errno != EACCES
+#endif
+					)
                 return false;
             buf[i] = '/';
         }


### PR DESCRIPTION
on cygwin/msys2 we may try to create something like (/cygdrive)/c/some/path/. An mkdir() attempt to create /c/ will fail with EACCESS. This needs to be catched.
Refers to https://github.com/Andersbakken/rtags/issues/1202