### PR TITLE
rtags support on openbsd

### DIFF
--- a/rct/Log.h
+++ b/rct/Log.h
@@ -141,7 +141,7 @@ public:
     Log(LogLevel level = LogLevel::Error, Flags<LogOutput::LogFlag> flags = LogOutput::DefaultFlags);
     Log(const Log &other);
     Log &operator=(const Log &other);
-#if defined(OS_Darwin)
+#if defined(OS_Darwin) || defined(__OpenBSD__)
 #ifndef __i386__
     Log operator<<(long number) { return addStringStream(number); }
 #endif

--- a/rct/MemoryMonitor.cpp
+++ b/rct/MemoryMonitor.cpp
@@ -69,6 +69,12 @@ static inline uint64_t usageFreeBSD()
 #warning "implement me"
     return 0;
 }
+#elif (__OpenBSD__)
+static inline uint64_t usageOpenBSD()
+{
+#warning "implement me"
+    return 0;
+}
 #elif defined(OS_DragonFly)
 static inline uint64_t usageDragonFly()
 {
@@ -122,6 +128,8 @@ uint64_t MemoryMonitor::usage()
     return usageLinux();
 #elif defined(OS_FreeBSD)
     return usageFreeBSD();
+#elif defined(__OpenBSD__)
+    return usageOpenBSD();
 #elif defined(OS_DragonFly)
     return usageDragonFly();
 #elif defined(OS_Darwin)


### PR DESCRIPTION
it also remove wordexp(works on linux) with glob. 

wordexp is not available on openbsd libc. wordexp code is not having a good reputation even available on linux. 

This fixes rtag build on openbsd
https://github.com/Andersbakken/rtags/issues/1261