### PR TITLE
fix strncpy usage

### DIFF
--- a/rct/SocketClient.cpp
+++ b/rct/SocketClient.cpp
@@ -244,7 +244,7 @@ bool SocketClient::connect(const String& path)
     };
     memset(&addr_un, '\0', sizeof(addr_un));
     addr_un.sun_family = AF_UNIX;
-    strncpy(addr_un.sun_path, path.constData(), sizeof(addr_un.sun_path));
+    strncpy(addr_un.sun_path, path.constData(), sizeof(addr_un.sun_path) - 1);
 
     SocketClient::SharedPtr unixSocket = shared_from_this();
 

--- a/rct/SocketServer.cpp
+++ b/rct/SocketServer.cpp
@@ -126,7 +126,7 @@ bool SocketServer::listen(const Path &p)
     };
     memset(&addr_un, '\0', sizeof(sockaddr_un));
     addr_un.sun_family = AF_UNIX;
-    strncpy(addr_un.sun_path, p.constData(), sizeof(addr_un.sun_path));
+    strncpy(addr_un.sun_path, p.constData(), sizeof(addr_un.sun_path) - 1);
 
     if (commonBindAndListen(&addr, sizeof(sockaddr_un))) {
         path = p;


### PR DESCRIPTION
From `strncpy` man page:

```
 Warning: If there is no null byte among the first n  bytes
       of src, the string placed in dest will not be null-terminated.
```

So copy just `buffer size - 1` bytes.