### PR TITLE
rct.cmake: Set CMP0022 policy to "OLD"

### DIFF
--- a/rct.cmake
+++ b/rct.cmake
@@ -4,6 +4,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(PkgConfig)
 
+if (POLICY CMP0022)
+  cmake_policy(SET CMP0022 OLD)
+endif ()
+
 if (POLICY CMP0025)
   cmake_policy(SET CMP0025 NEW)
 endif ()


### PR DESCRIPTION
rct would fail to build due to the following error:
  Target "rct" has policy CMP0022 enabled, but also has old-style
  LINK_INTERFACE_LIBRARIES properties populated, but it was exported without
  the EXPORT_LINK_INTERFACE_LIBRARIES to export the old-style properties

This patch fixes that error by setting CMP0022 policy to "OLD".

Reported by aschmitz-crnc in
<https://github.com/Andersbakken/rct/issues/86>

* rct.cmake: Set CMP0022 to "OLD".